### PR TITLE
Enabled prettyurls all the time

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,7 +51,6 @@ makedocs(
          sitename = "JsonGrinder.jl",
          # doctest = false,
          format = Documenter.HTML(sidebar_sitename=false,
-                                  prettyurls=get(ENV, "CI", nothing) == "true",
                                   assets=["assets/favicon.ico", "assets/custom.css"]),
          modules = [JsonGrinder],
          pages = [


### PR DESCRIPTION
As described here, it is probably best to use (the default) `prettyurls=true` and run a local webserver with

```python
python3 -m http.server --bind localhost
```

in `docs/build`.

The `prettyurls = get(ENV, "CI", nothing) == "true"` solution breaks either on a server or locally when using relative paths to pictures. This isn't manifested in JsonGrinder docs now, because all images are in `index.html` in root, but it may be a problem if more illustrations are added.