### PR TITLE
Minor grammar and formatting fixes for the docs homepage

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,11 +3,11 @@
 <img class="display-dark-only" src="assets/logo-dark.svg" alt="JsonGrinder.jl logo" /style="width: 50%;">
 ```
 
-**JsonGrinder** is a collection of routines that facilitates conversion of JSON documents into structures used by [Mill.jl](https://github.com/CTUAvastLab/Mill.jl) project.
+**JsonGrinder** is a collection of routines that facilitates conversion of JSON documents into structures used by the [Mill.jl](https://github.com/CTUAvastLab/Mill.jl) project.
 
 ## Motivation
 
-Imagine that you want to train a classifier on data looking like this
+Imagine that you want to train a classifier on data that looks like this:
 ```json
 {
   "ind1": 1,
@@ -72,28 +72,31 @@ Imagine that you want to train a classifier on data looking like this
 
 ```
 and the task is to predict the value in key `mutagenic` (in this sample it's `1`) from the rest of the JSON.
-
 With most machine learning libraries assuming your data being stored as tensors of a fixed dimension, or a sequence, you will have a bad time. 
-Contrary, `JsonGrider.jl` assumes your data to be stored in a flexible JSON format and tries to automate most labor using reasonable default, but it still gives you an option to control and tweak almost everything. 
+
+In contrast, `JsonGrider.jl` assumes your data to be stored in a flexible JSON format, and tries to automate most labor using reasonable defaults, while still giving you an option to control and tweak almost everything.
 `JsonGrinder.jl` is built on top of [Mill.jl](https://github.com/CTUAvastLab/Mill.jl) which itself is built on top of [Flux.jl](https://fluxml.ai/) (we do not reinvent the wheel). 
-**Although JsonGrinder was designed for JSON files, you can easily adapt it to XML, [Protocol Buffers](https://developers.google.com/protocol-buffers), [MessagePack](https://msgpack.org/index.html), and other similar structures**
+
+!!! note
+
+    Although JsonGrinder was designed for JSON files, you can easily adapt it to XML, [Protocol Buffers](https://developers.google.com/protocol-buffers), [MessagePack](https://msgpack.org/index.html), and other similar structures.
 
 There are 5 steps to create a classifier once you load the data.
 
 1. Create a schema of JSON files (using `sch = JsonGrinder.schema(...)`).
 2. Create an extractor converting JSONs to Mill structures (`extractor = suggestextractor(sch)`). 
-Schema `sch` from previous step is very helpful, as it helps to identify, how to convert nodes (`Dict`, `Array`) to (`Mill.ProductNode` and `Mill.BagNode`) and how to convert values in leaves to (`Float32`, `Vector{Float32}`, `String`, `Categorical`).
-3. Create a model for your JSONs, which can be easily done by (using `model = reflectinmodel(sch, extractor,...)`)
+   Schema `sch` from previous step is very helpful, as it helps to identify how to convert nodes (`Dict`, `Array`) to (`Mill.ProductNode` and `Mill.BagNode`) and how to convert values in leaves to (`Float32`, `Vector{Float32}`, `String`, `Categorical`).
+3. Create a model for your JSONs, which can be easily done (by using `model = reflectinmodel(sch, extractor,...)`)
 4. Extract your JSON files into Mill structures using extractor `extractbatch(extractor, samples)` (at once if all data fit to memory, or per-minibatch during training)
 5. Use your favourite methods to train the model, it is 100% compatible with `Flux.jl` tooling.
 
-Steps 1 and 2 are handled by `JsonGrinder.jl`, steps 3 and 4 by combination of `Mill.jl` `JsonGrinder.jl` and the 5. step by a combination of `Mill.jl` and `Flux.jl`.
+Steps 1 and 2 are handled by `JsonGrinder.jl`, steps 3 and 4 by combination of `Mill.jl` `JsonGrinder.jl` and the 5th step by a combination of `Mill.jl` and `Flux.jl`.
 
 Authors see the biggest advantage in the `model` being hierarchical and reflecting the JSON structure. Thanks to `Mill.jl`, it can handle missing values at all levels.
 
-Our idealized workflow is demonstrated in following example, which can be also found in [Mutagenesis Example](@ref) and here we'll break it down in order to demonstrate the basic functionality of JsonGrinder.
+Our idealized workflow is demonstrated in following example, which can be also found in [Mutagenesis Example](@ref). Here we'll break it down in order to demonstrate the basic functionality of JsonGrinder.
 
-The basic workflow can be visualized as follows
+The basic workflow can be visualized as follows:
 
 ```@raw html
 <img class="display-light-only" src="assets/workflow.svg" alt="JsonGrinder workflow" style="width: 30%;"/>
@@ -109,4 +112,4 @@ Markdown.parse(str)
 
 This concludes a simple classifier for JSON data.
 
-But keep in mind the framework is general and given its ability to embed hierarchical data into fixed-size vectors, it can be used for classification, regression, and various other ML tasks.
+But keep in mind that the framework is general, and given its ability to embed hierarchical data into fixed-size vectors, it can be used for classification, regression, and various other ML tasks.

--- a/examples/mutagenesis.jl
+++ b/examples/mutagenesis.jl
@@ -1,7 +1,7 @@
 #src this layout is heavily inspired by how examples in https://github.com/Ferrite-FEM/Ferrite.jl are generated
 
 # # Mutagenesis Example
-# Following example demonstrates learning to [predict the mutagenicity on Salmonella typhimurium](https://relational.fit.cvut.cz/dataset/Mutagenesis) (dataset is stored in json format [in MLDatasets.jl](https://juliaml.github.io/MLDatasets.jl/stable/datasets/Mutagenesis/) for your convenience).
+# The following example demonstrates learning to [predict the mutagenicity on Salmonella typhimurium](https://relational.fit.cvut.cz/dataset/Mutagenesis) (dataset is stored in JSON format [in MLDatasets.jl](https://juliaml.github.io/MLDatasets.jl/stable/datasets/Mutagenesis/) for your convenience).
 
 #md # !!! tip
 #md #     This example is also available as a Jupyter notebook, feel free to run it yourself:
@@ -16,81 +16,79 @@
 # This example is taken from the [CTUAvastLab/JsonGrinderExamples](https://github.com/CTUAvastLab/JsonGrinderExamples/blob/main/mutagenesis/tuned.jl)
 # and heavily commented for more clarity.
 
-# Here we include libraries all necessary libraries
+# Here we include all necessary libraries:
 using JsonGrinder, Mill, Flux, MLDatasets, Statistics, Random, JSON3, OneHotArrays
 
-# we stabilize the seed to obtain same results every run, for pedagogic purposes
+# We stabilize the seed to obtain same results every run, for pedagogic purposes:
 Random.seed!(42)
 
-# We define the minibatch size.
+# We define the minibatch size:
 BATCH_SIZE = 10
 
-# Here we load the training samples.
+# Here we load the training samples:
 dataset_train = MLDatasets.Mutagenesis(split=:train);
 x_train = dataset_train.features
 y_train = dataset_train.targets
 
-#md # This is the **step 1** of the workflow
+#md # ### Step 1
 #md #
 # We create the schema of the training data, which is the first important step in using the JsonGrinder.
 # This computes both the structure (also known as JSON schema) and histogram of occurrences of individual values in the training data.
 sch = JsonGrinder.schema(x_train)
 
-#md # This is the **step 2** of the workflow
+#md # ### Step 2
 #md #
-# Then we use it to create the extractor converting jsons to Mill structures.
-# The `suggestextractor` is executed below with default setting, but it allows you heavy customization.
+# Then we use it to create the extractor converting JSONs to Mill structures.
+# The `suggestextractor` is executed below with default setting, but it also allows you heavy customization.
 extractor = suggestextractor(sch)
 
-#md # This is the **step 3** of the workflow, we create the model using the schema and extractor
+#md # ### Step 3: Create the model using the schema and extractor
 #md #
-# # Create the model
-# We create the model reflecting structure of the data
+# We create the model reflecting structure of the data:
 encoder = reflectinmodel(sch, extractor, d -> Dense(d, 10, relu))
-# this allows us to create model flexibly, without the need to hardcode individual layers.
+# This allows us to create model flexibly, without the need to hardcode individual layers.
+#
 # Individual arguments of `reflectinmodel` are explained in [Mill.jl documentation](https://CTUAvastLab.github.io/Mill.jl/stable/manual/reflectin/#Model-Reflection).
 # But briefly: for every numeric array in the sample, model will create a dense layer with `neurons` neurons (20 in this example).
 # For every vector of observations (called bag in Multiple Instance Learning terminology), it will create aggregation function which will take mean, maximum of feature vectors and concatenate them.
 # The `fsm` keyword argument basically says that on the end of the NN, as a last layer, we want 2 neurons `length(labelnames)` in the output layer, not 20 as in the intermediate layers.
-# then we add layer with 2 output of the model at the end of the neural network
+# Then we add layer with 2 output of the model at the end of the neural network
 model = Dense(10, 2) ∘ encoder
 
-#md # This is the **step 4** of the workflow, we call the extractor on each sample
-#md #
-# We convert jsons to mill data samples and prepare list of classes. This classification problem is two-class, but we want to infer it from labels.
+#md # ### Step 4: Call the extractor on each sample.
+# We convert JSONs to Mill data samples and prepare list of classes. This classification problem is two-class, but we want to infer it from labels.
 # The extractor is callable, so we can pass it vector of samples to obtain vector of structures with extracted features.
 ds_train = extractor.(x_train)
 
-#md # This is the **step 5** of the workflow, we train the model
+#md # ### Step 5: Train the model
 #md #
-# # Train the model
-# Then, we define few handy functions and a loss function, which is logit binary crossentropy in our case.
+# Then, we define a few handy functions and a loss function, which is logit binary crossentropy in our case.
 # Here we add +1 to labels, because the labels are {0,1} and idxmax of the model output is in the {1,2} range.
 loss(ds, y) = Flux.Losses.logitbinarycrossentropy(model(ds), OneHotArrays.onehotbatch(y .+ 1, 1:2))
 accuracy(ds, y) = mean(Flux.onecold(model(ds)) .== y .+ 1)
 
-# We prepare the optimizer.
+# We prepare the optimizer:
 opt = AdaBelief()
 ps = Flux.params(model)
 
-# Lastly we turn our training data to minibatches, and we can start training
+# Lastly we turn our training data to minibatches, and we can start training:
 data_loader = Flux.DataLoader((ds_train, y_train), batchsize=BATCH_SIZE, shuffle=true)
 
-# We can see the accuracy rising and obtaining over 80% quite quickly
+# We can see the accuracy rising and obtaining over 80% quite quickly:
 for i in 1:10
     @info "Epoch $i"
     Flux.Optimise.train!(loss, ps, data_loader, opt)
     @show accuracy(ds_train, y_train)
 end
 
-# # Classify test set
-# The Last part is inference and evaluation on test data.
+# ## Classify test set
+# The last part is inference and evaluation on test data.
 dataset_test = MLDatasets.Mutagenesis(split=:test);
 x_test = dataset_test.features
 y_test = dataset_test.targets
 ds_test = extractor.(x_test)
 
-# we see that the test set accuracy is also over 80%
+# We see that the test set accuracy is also over 80%
 @show accuracy(ds_test, y_test)
 
 probs = softmax(model(ds_test))
@@ -98,21 +96,20 @@ o = Flux.onecold(probs)
 mean(o .== y_test .+ 1)
 
 # `pred_classes` contains the predictions for our test set.
-# we see the accuracy is around 75% on test set
-# predicted classes for test set
+# We see the accuracy is around 75% on predicted classes for test set
 o
-# Ground truth classes for test set
+# Ground truth classes for test set:
 y_test .+ 1
-# probabilities for test set
+# Probabilities for test set:
 probs
 
-# We can look at individual samples. For instance, some sample from test set is
+# We can look at individual samples. For instance, some sample from test set is:
 ds_test[2]
 
-# and the corresponding classification is
+# and the corresponding classification is:
 y_test[2] + 1
 
-# if you want to see the probability distribution, it can be obtained by applying `softmax` to the output of the network.
+# If you want to see the probability distribution, it can be obtained by applying `softmax` to the output of the network:
 softmax(model(ds_test[2]))
 
-# so we can see that the probability that given sample belongs to the first class is > 60%.
+# So we can see that the probability that given sample belongs to the first class is > 60%.


### PR DESCRIPTION
Various grammar/writing style changes and some Markdown formatting changes, in order to make the documentation homepage more readable and consistent. (Also includes edits to  `examples/mutagenesis.jl`, since its contents are pulled into the homepage too.) 